### PR TITLE
Add CNAME file to repo

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,5 @@
 module.exports = function(eleventyConfig) {
+  eleventyConfig.addPassthroughCopy('src/CNAME');
   eleventyConfig.addPassthroughCopy('src/css/*.css');
   eleventyConfig.addPassthroughCopy('src/favicon.ico');
   eleventyConfig.addPassthroughCopy('src/img/**/*');

--- a/src/CNAME
+++ b/src/CNAME
@@ -1,0 +1,1 @@
+juggercouncil.org


### PR DESCRIPTION
# Issue Addressed
This PR makes further progress on #5 .

# Description
Add `CNAME` file as per Github Pages docs and ensure this is copied to the `_site` directory on build.

# Tests
Ran `npm run build`, double-checked that `CNAME` is copied to `_site`.