### PR TITLE
force sizing on images for map

### DIFF
--- a/src/js/map.js
+++ b/src/js/map.js
@@ -95,7 +95,7 @@ function initMap() {
     var info_window_string = `<div id="content">`;
     if (club_data[logo_col]) {
       // if we have a logo to show, jam everything into a table and put the logo on one side of it.
-      info_window_string += `<table><tr><td style="padding-right:15px"><img src= ${club_data[logo_col]}></td><td>`
+      info_window_string += `<table><tr><td style="padding-right:15px;background-image:url(${club_data[logo_col]});background-repeat:no-repeat;width:150px;height:150px;background-size:contain;background-position:center;"></td><td>`
     }
     info_window_string += `
       <h1 id="firstHeading" class="firstHeading">


### PR DESCRIPTION
# Issue Addressed
This PR addresses #28 

# Description
Images in the map are now forced to be a particular size.

# Tests
I actually didn't test this and we will have to test in prod, because the map keys aren't set to work on localhost. I did try out the css changes in the developer console, though, so I'm pretty confident it will work.
