### PR TITLE
Add Google Analytics tag

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -19,6 +19,16 @@ jsIncludes:
       <link rel="stylesheet" href="{{ css | url }}">
     {% endfor %}
     <script src="https://kit.fontawesome.com/b248b23f0a.js" crossorigin="anonymous"></script>
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-BB57JV9T5D"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-BB57JV9T5D');
+    </script>
   </head>
   <body>
     <div id="ijc_modal_lang_warning" class="modal">


### PR DESCRIPTION
# Issue Addressed
This PR closes #13 .

# Description
I've added a Google Analytics tag to the IJC website, so that we can better understand where our website visitors are coming from.  This will in turn help us prioritize work on language translations, community-specific outreach, and so on.

# Tests
Will need to test once deployed, probably by leaving it there for a bit and then looking at analytics reports.