### PR TITLE
Integrate German copy

### DIFF
--- a/src/_data/nav.js
+++ b/src/_data/nav.js
@@ -15,7 +15,7 @@ module.exports = {
       pageKey: 'play',
       pageSection: 'start_a_club',
     }, {
-      label: 'Verbinde mit der Community',
+      label: 'Sag »Hallo!«',
       pageKey: 'play',
       pageSection: 'connect_with_community',
     }],

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -1,8 +1,8 @@
 module.exports = {
   buildTime: new Date(),
   de: {
-    metaTitle: 'Der Internationaler Rat der Jugger',
-    metaDescription: 'Der International Jugger Council (IJC) ist eine Vertretung der weltweiten Jugger-Community.',
+    metaTitle: 'Das International Jugger Council',
+    metaDescription: 'Das International Jugger Council (IJC) ist eine Vertretung der weltweiten Jugger-Community.',
     navLanguage: 'Sprache',
   },
   en: {

--- a/src/_includes/de/connect_with_community.njk
+++ b/src/_includes/de/connect_with_community.njk
@@ -1,4 +1,4 @@
 <p>
-  A very important part of the jugger experience is to meet and stay in touch with new people.  Not sure how to do that?  These links will help you <strong>get in contact with your local, national, and international jugger community.</strong>  People in these forums and groups can point you in the right direction.
+  Am besten läßt es sich juggern, wenn man sich mit anderen darüber austauschen kann. Nicht sicher, wie das geht? Diese Links helfen dir, <strong>mit deiner lokalen, nationalen und internationalen Jugger-Gemeinde in Kontakt zu treten</strong>. In diesen Foren und Gruppen findest du Hilfe.
 </p>
 {% include 'connectCommunity.njk' %}

--- a/src/_includes/de/find_a_club.njk
+++ b/src/_includes/de/find_a_club.njk
@@ -1,13 +1,13 @@
 <div class="columns is-desktop">
   <div class="column">
     <p class="is-size-4">
-      Jugger can be played almost anywhere!
+      Jugger wird an immer mehr Orten auf der Welt gespielt!
     </p>
     <p>
-      There are jugger clubs in <strong>thirty countries across Europe, Asia, Oceania and the Americas</strong>. Check our Jugger World Map to see if there’s any such group near you - but if there isn’t, grab your friends and start one!
+      Heute gibt es bereits Juggervereine und -gruppen in <strong>30 Ländern in Europa, Asien, Ozeanien und Amerika</strong>. Auf der Jugger-Weltkarte des IJC können Gruppen in der Nähe gefunden werden. Falls es noch keine gibt – dann ist es höchste Zeit, eine eigene ins Leben zu rufen!
     </p>
     <p class="is-size-3">
-      <a href="{{ '/de/map' | url }}">Browse the map</a>
+      <a href="{{ '/de/map' | url }}">Karte durchsuchen</a>
     </p>
   </div>
   <div class="column">

--- a/src/_includes/de/footer.njk
+++ b/src/_includes/de/footer.njk
@@ -1,3 +1,4 @@
 Verbinde dich mit dem IJC bei <a href="https://discord.gg/jXqhcYu">Discord</a> oder per <a href="mailto://juggerinternational@gmail.com">E-mail</a><br/><br/>
-Logo by María Chavarría<br/>
-Webseite by Evan Savage & Valkyrie Savage<br/>
+Logo von <a href="https://www.instagram.com/iriel89">María Chavarría</a><br/>
+Übersetzung von <a href="https://www.linkedin.com/in/arturo-perez-amores">Arturo Pérez Amores</a></br>
+<a href="https://github.com/international-jugger-council/ijc-website/graphs/contributors">Siehe Webseite-Mitarbeiters</a><br/>

--- a/src/_includes/de/mission_statement.njk
+++ b/src/_includes/de/mission_statement.njk
@@ -3,23 +3,23 @@
     <article class="message">
       <div class="message-body has-text-left is-size-5">
         <p>
-          We want to know where jugger is played, how it is played, and what they need from us to grow.
+          Wir wollen wissen, wo Jugger gespielt wird, wie es gespielt wird und was die Jugger-Gruppen von uns brauchen, um zu wachsen.
         </p>
         <p class="mt-2">
-          We want to gather experts and volunteers from around the world to provide all the material and agreements needed to support that growth.
+          Wir wollen Experten und Freiwillige aus der ganzen Welt zusammenbringen, um alle Materialien und Vereinbarungen bereitzustellen, die zur ihrer Unterstützung erforderlich sind.
         </p>
         <p class="mt-2">
-          We want to make it easier to compete with other juggers from around the world.
+          Wir wollen es einfacher machen, mit anderen Juggern aus der ganzen Welt zu konkurrieren.
         </p>
       </div>
     </article>
   </div>
   <div class="column">
     <p>
-      <strong>The IJC Mission Statement was adopted on October 2, 2019</strong> as part of its first Charter:
+      <strong>Am 2. Oktober 2019 nahm das IJC seine erste Charta an:</strong>
     </p>
     <p class="mt-4 is-size-3">
-      <a href="https://docs.google.com/document/d/1SUXlLNPV6Kx9I2xVxt3OhHyd2PUB94KuWtNW8JV0xo0/edit?usp=sharing">IJC Charter</a>
+      <a href="https://docs.google.com/document/d/1SUXlLNPV6Kx9I2xVxt3OhHyd2PUB94KuWtNW8JV0xo0/edit?usp=sharing">IJC-Charta</a>
     </p>
   </div>
 </div>
@@ -28,12 +28,12 @@
 
 <div class="columns is-desktop">
   <div class="column">
-    <h3 class="is-size-3 mb-4">Code of Conduct</h3>
+    <h3 class="is-size-3 mb-4">Verhaltenskodex</h3>
     <p>
-      Do you coach other juggers, promote your club locally, organize tournaments, or otherwise serve as a leader in your local jugger club?  <strong>The IJC Code of Conduct can help you create an safe, enjoyable and inclusive environment</strong> for the sport of jugger.
+      Trainierst du andere Jugger, förderst du deinen Club vor Ort, organisierst du Turniere oder bekleidest du auf andere Weise eine Führungsposition in deiner lokalen Jugger-Organisation? Der IJC-Verhaltenskodex bietet einen nützlichen Ausgangspunkt, um <strong>ein sicheres, angenehmes und integratives Umfeld für den Jugger-Sport zu schaffen</strong>.
     </p>
     <p class="is-size-3">
-      <a href="https://docs.google.com/document/d/1PA8wOP_-ITgONZFS6FuFjjPXXVSUNqZY6RtcvfJF268/edit">IJC Code of Conduct</a>
+      <a href="https://docs.google.com/document/d/1PA8wOP_-ITgONZFS6FuFjjPXXVSUNqZY6RtcvfJF268/edit">IJC-Verhaltenskodex</a>
     </p>
   </div>
   <div class="column">

--- a/src/_includes/de/rules.njk
+++ b/src/_includes/de/rules.njk
@@ -1,13 +1,13 @@
 <div class="columns is-desktop">
   <div class="column">
     <p>
-      As a sport, <strong>Jugger is a work in progress: we don't yet have a single global ruleset!</strong> There are around 20 different national and local variants.  Most of these variants agree on basic rules, but there are differences in areas like refereeing and dimensions of equipment.
+      2020 gibt es weltweit noch <strong>kein weltweit einheitliches Juggerregelwerk.</strong> Es bestehen rund 20 verschiedene nationale und lokale Regelwerke, von denen sich die meisten in den Grundregeln gleichen, sich jedoch in bestimmten Bereichen unterscheiden, wie beispielsweise in der Länge oder Ausgestaltung von Spielgeräten und Jugg.
     </p>
     <p>
-      The most widely used rulesets are the German, Spanish, and Australian rulesets.  We're currently working on a tool to help players understand these different rulesets - in the meantime, check out the International Jugger Blog’s Rulebooks compilation!
+      Wir arbeiten derzeit an der Erstellung einer Vergleichsdatenbank für die deutschen, spanischen und australischen Regeln. Zum Vergleich können die Regelwerke im Regelarchiv des International Jugger Blog herangezogen werden:
     </p>
     <p class="is-size-3">
-      <a href="https://www.juggerblog.net/index.php?/archives/139-International-Jugger-rulebooks-Jugger-Archive-I.html">Check out international rulesets</a>
+      <a href="https://www.juggerblog.net/index.php?/archives/139-International-Jugger-rulebooks-Jugger-Archive-I.html">Check die internationalen Regeln</a>
     </p>
   </div>
   <div class="column">

--- a/src/_includes/de/start_a_club.njk
+++ b/src/_includes/de/start_a_club.njk
@@ -1,10 +1,10 @@
 <div class="columns">
   <div class="column">
     <p>
-      Have you just discovered jugger and want to bring it closer to home? Are you already a jugger player and wish to take your favourite sport when you move to a new town?
+      Möchtest du eine eigene Juggergruppe gründen? Bist du bereits ein Jugger und möchtest deinen Lieblingssport auch dann noch ausüben, wenn du in eine neue Stadt ohne eigenen Juggerverein ziehst? Kein Problem!
     </p>
     <p>
-      We've linked to some <strong>useful guides and tutorials</strong> to help you get started.
+      Hier gibt es einige Sammlungen nützlicher <strong>Anleitungen und Tipps</strong> zum Planen von Trainings und zum Erstellen von Pompfen.
     </p>
   </div>
   <div class="column">

--- a/src/_includes/de/the_ijc.njk
+++ b/src/_includes/de/the_ijc.njk
@@ -1,13 +1,13 @@
 <div class="columns is-desktop">
   <div class="column">
     <p>
-      We <strong>help organize juggers to work together in growing and building the future of this sport</strong>, and provide a forum for the community to discuss rules, competition, and cooperation in jugger.
+      Wir <strong>helfen dabei, Juggers zu organisieren, um gemeinsam die Zukunft dieses Sports zu fördern und aufzubauen</strong>.  Wir bieten auch der Jugger-Community ein Forum, um Regeln, Wettbewerb und Zusammenarbeit zu diskutieren.
     </p>
     <p>
-      You can learn more about the Committees of the IJC and how to volunteer here:
+      Weitere Informationen über die Arbeitsweise und Mitgestaltungsmöglichkeiten an IJC-Komitees finden sich hier:
     </p>
     <p class="is-size-3">
-      <a href="{{ '/de/about' | url }}">Get involved</a>
+      <a href="{{ '/de/about' | url }}">Mehr erfahren</a>
     </p>
   </div>
   <div class="column has-text-centered">

--- a/src/_includes/de/what_is_jugger.njk
+++ b/src/_includes/de/what_is_jugger.njk
@@ -1,10 +1,10 @@
 <div class="columns is-desktop">
   <div class="column">
     <p>
-      <strong>Jugger is a mixed (co-ed) contact sport</strong> where two teams of five players, outfitted with padded spars, compete to grab a ball placed in the center of the field and bring it to the opponent’s goal. The game was developed in its current form in Germany during the early 90’s, and is currently played in 30 countries across the world.
+      <strong>Jugger ist eine Mischung aus Mannschafts- und Einzelsport.</strong> Eine Mannschaft besteht aus fünf Spielern. Vier davon führen »Pompfen«, Spielgeräte, mit denen sie ihre Gegner zu berühren versuchen. Allein die fünfte Spielerin bzw. der fünfte Spieler kann den »Jugg« genannten Ball aufnehmen und ins gegnerische Tor tragen, ins »Mal«, um einen Punkt zu erzielen. Der Sport wurde aus einem Film heraus in den frühen 90ern in Deutschland entwickelt. Er wird heutzutage in 30 Ländern auf der ganzen Welt gespielt.
     </p>
     <p class="is-size-3">
-      <a href="{{ '/de/play' | url }}">Regeln</a> |
+      <a href="{{ '/de/play' | url }}">So wird gespielt</a> |
       <a href="{{ '/de/map' | url }}">Finde Verein</a>
     </p>
   </div>

--- a/src/_includes/de/who_we_are.njk
+++ b/src/_includes/de/who_we_are.njk
@@ -1,5 +1,5 @@
 <p>
-  The IJC is a volunteer-run organization, run by juggers who take an interest in supporting and growing the sport of jugger.  If you're interested in learning more, want to help as a volunteer, or have feedback, comments, or questions - contact us!
+  Das IJC ist eine nichtkommerzielle Organisation, die von Juggern geleitet wird, die sich für die Unterstützung und das Wachstum des Jugger-Sports interessieren. Wenn du mehr erfahren, als Freiwilliger helfen möchtest oder Feedback, Kommentare oder Fragen hast – zögere nicht, uns zu kontaktieren!
 </p>
 {% include 'contactsIJC.njk' %}
 
@@ -7,33 +7,33 @@
 
 <div class="columns is-desktop">
   <div class="column">
-    <h3 class="is-size-3 mb-4">Support Us!</h3>
+    <h3 class="is-size-3 mb-4">Unterstütze uns!</h3>
     <p>
-      There are no membership fees - the IJC is a non-profit forum and is funded via individual donations. If you like the objectives we’re working to achieve, please consider supporting us by sending a small amount of money to our account! To get the bank details, just get in touch with the Treasurer via Discord or email.
+      Es gibt keine Mitgliedsbeiträge - das IJC ist ein nichtkommerzielles Forum und wird durch Einzelspenden finanziert. Wenn dir die Ziele gefallen, an denen wir arbeiten, kannst du uns unterstützen, indem du einen kleinen Geldbetrag auf unser Konto überweist. Um die Bankdaten zu erhalten, setz dich einfach per Discord oder E-Mail mit der Schatzmeisterin in Verbindung.
     </p>
     <p>
-      We can include your (or your organization's) name in our Top Supporters List.  Anonymous donations are also accepted!
+      Wir können deinen Namen (oder den Namen deiner Organisation) in unsere Liste der Hauptgebern aufnehmen. Anonyme Spenden werden ebenfalls akzeptiert.
     </p>
   </div>
   <div class="column">
-    <h4 class="is-size-3 mb-4">Top Supporters List</h4>
+    <h4 class="is-size-3 mb-4">Hauptsponsoren</h4>
     {% include 'supporters.njk' %}
   </div>
 </div>
 
 <hr>
 
-<h3 class="is-size-3 mb-4">How the IJC Works</h3>
+<h3 class="is-size-3 mb-4">Wie das IJC funktioniert</h3>
 <div class="columns">
   <div class="column">
     <p>
-      The International Jugger Council was founded in 2019 to serve as a representative body for the worldwide jugger community.   This map shows IJC member countries and organizations around the world.
+      Das International Jugger Council (IJC) wurde am 2. Oktober 2019 als Vertretung für die weltweite Jugger-Gemeinschaft gegründet. Zu ihren Aufgaben gehören Erörterung und Abstimmung von Regelfragen, des Wettbewerbs und der Zusammenarbeit. Diese Karte zeigt Länder und Organisationen Mitglieder des IJC.
     </p>
     <p>
-      The Council comprises 1-3 Representatives from each member country, and each nation’s representatives share one vote. The Council elects a Board every year, which calls ordinary meetings every October and April and extraordinary meetings whenever the situation requires it.
+      Der Rat besteht aus 1-3 Vertreterinnen und Vertretern seiner Mitgliedsländer, die sich jeweils eine Stimme teilen. Der Rat wählt jedes Jahr einen Vorstand, der im Oktober und April ordentliche Sitzungen einberuft. Bei Bedarf können außerordentliche Sitzungen einberufen werden.
     </p>
     <p>
-      Once the Council has agreed on setting a new goal for the IJC, the Board establishes a Committee to work on it.
+      Wenn der Rat sich auf ein neues Thema geeinigt hat, wird durch den Vorstand ein Komitee eingesetzt.
     </p>
   </div>
   <div class="column">
@@ -44,17 +44,16 @@
 
 <hr>
 
-<h3 class="is-size-3 mb-4">IJC Board</h3>
+<h3 class="is-size-3 mb-4">IJC-Vorstand</h3>
 <p>
-  The Board is responsible for managing the International Jugger Council.
-  Its current members are:
+  Der Vorstand ist verantwortlich für die Verwaltung des IJC. In alphabetischer Reihenfolge sind die aktuellen Mitglieder:
 </p>
 {% include 'boardIJC.njk' %}
 
 <hr>
 
-<h3 class="is-size-3 mb-4">IJC Committees</h3>
+<h3 class="is-size-3 mb-4">IJC-Komitees</h3>
 <p>
-  These committees help the IJC realize its mission.  If there's a particular committee or area you'd like to help out with, you can also reach out to the relevant Commissioner on Discord!
+  Diese Komitees helfen dem IJC, seine Mission zu verwirklichen. Wenn es ein bestimmtes Komitee oder einen Bereich gibt, bei dem du helfen möchtest, kannst du dich auch an den zuständigen Kommissar per Discord wenden.
 </p>
 {% include 'committeesIJC.njk' %}

--- a/src/_includes/en/footer.njk
+++ b/src/_includes/en/footer.njk
@@ -1,3 +1,3 @@
 Connect with the IJC on <a href="https://discord.gg/jXqhcYu">Discord</a> or via <a href="mailto://juggerinternational@gmail.com">email</a><br/><br/>
-logo by María Chavarría<br/>
-site by Evan Savage & Valkyrie Savage<br/>
+logo by <a href="https://www.instagram.com/iriel89">María Chavarría</a><br/>
+<a href="https://github.com/international-jugger-council/ijc-website/graphs/contributors">See website contributors</a><br/>

--- a/src/_includes/es/footer.njk
+++ b/src/_includes/es/footer.njk
@@ -1,4 +1,4 @@
 Conéctese con el CIJ en <a href="https://discord.gg/jXqhcYu">Discord</a> o por <a href="mailto://juggerinternational@gmail.com">correo electrónico</a><br/><br/>
-logotipo por María Chavarría<br/>
-sitio por Evan Savage & Valkyrie Savage<br/><br/>
-traducción por Arturo Pérez Amores
+logotipo por <a href="https://www.instagram.com/iriel89">María Chavarría</a><br/>
+traducción por <a href="https://www.linkedin.com/in/arturo-perez-amores">Arturo Pérez Amores</a></br>
+<a href="https://github.com/international-jugger-council/ijc-website/graphs/contributors">ver colaboradores del sitio web</a><br/>

--- a/src/de/index.html
+++ b/src/de/index.html
@@ -11,7 +11,7 @@ pageKey: index
   </section>
 
   <section>
-    {{ headerHero('the_ijc', 'Der IJC' ) }}
+    {{ headerHero('the_ijc', 'Das IJC' ) }}
     {{ pageSection('the_ijc') }}
   </section>
 </div>

--- a/src/de/play/index.html
+++ b/src/de/play/index.html
@@ -22,7 +22,7 @@ title: Jugger spielen
   </section>
 
   <section>
-    {{ headerHero('connect_with_community', 'Verbinde mit der Community' ) }}
+    {{ headerHero('connect_with_community', 'Sag »Hallo!«' ) }}
     {{ pageSection('connect_with_community') }}
   </section>
 </div>

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,10 +1,11 @@
 const LANGS_SUPPORTED = [
+  'de',
   'en',
   'es',
-  'de',
 ];
 
 const LANGS_TRANSLATED = [
+  'de',
   'en',
   'es',
 ];
@@ -54,10 +55,14 @@ function setPageLang() {
     return;
   }
   if (!LANGS_TRANSLATED.includes(lang)) {
-    const $modalLangWarning = document.querySelector('#ijc_modal_lang_warning');
-    $modalLangWarning.classList.add('is-active');
+    openModalLangWarning();
   }
   setLang(lang);
+}
+
+function openModalLangWarning() {
+  const $modalLangWarning = document.querySelector('#ijc_modal_lang_warning');
+  $modalLangWarning.classList.add('is-active');
 }
 
 function closeModalLangWarning() {


### PR DESCRIPTION
# Issue Addressed
This PR closes #23 .

# Description
I've updated the German-language version of the site to include the copy we've had for a while.  In the process, I updated the attribution blurb at bottom to link to sites, to include translation credits for both Spanish and German, and to link to the Contributors page of this repository so everyone who's worked on the website can receive credit!

# Tests
Quickly checked in frontend across all three languages, to verify that footer and overall copy changes look good. 
